### PR TITLE
Move babel-eslint & eslint-config-airbnb to dependencies section

### DIFF
--- a/packages/eslint-config-shakacode/README.md
+++ b/packages/eslint-config-shakacode/README.md
@@ -5,10 +5,7 @@ Shakacode `eslint` config.
 ## Install
 
 ```bash
-npm install --save-dev eslint-config-shakacode eslint-config-airbnb eslint
-
-# We need Babel as we use experimental features and flow syntax
-npm install --save-dev babel-eslint
+npm install --save-dev eslint-config-shakacode
 
 # If it's React project
 npm install --save-dev eslint-plugin-react

--- a/packages/eslint-config-shakacode/package.json
+++ b/packages/eslint-config-shakacode/package.json
@@ -21,8 +21,13 @@
     "release:major": "scripts/release major"
   },
   "peerDependencies": {
-    "babel-eslint": "*",
-    "eslint": "*",
-    "eslint-config-airbnb": "*"
+    "eslint": ">=1.0.0"
+  },
+  "dependencies": {
+    "babel-eslint": "^5.0.0-beta6",
+    "eslint-config-airbnb": "^2.1.1"
+  },
+  "devDependencies": {
+    "eslint": "^1.10.3"
   }
 }


### PR DESCRIPTION
Reason: we should depend on specified major version of these packages, b/c otherwise they can be updated to the next major version, but we will still be depending on rules from the previous one.

And I think we should make it a major `2.0.0` update.

@justin808 @robwise

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/style-guide-javascript/6)

<!-- Reviewable:end -->
