### PR TITLE
Fix a typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Our **JavaScript Style Guide** is relatively simple because we're leveraging the
 
 Here's a few notes on top of that:
 
-1. **Line Length**: We're sticking with the AirBnb standard of 100. See [their reasoning](https://github.com/airbnb/javascript/pull/458). Any strings greater than 100 should be broken up into multiple lines.
+1. **Line Length**: We're sticking with the AirBnb standard of 120. See [their reasoning](https://github.com/airbnb/javascript/pull/458). Any strings greater than 120 should be broken up into multiple lines.
 1. Check out the [AirBnb React Guide](https://github.com/airbnb/javascript/blob/master/react/README.md) keeping in mind the exceptions listed below.
 1. Use ES6 classes for React components.
 


### PR DESCRIPTION
Because [use 120 max-len](https://github.com/airbnb/javascript/pull/458)
## 

I've forked the repo just to fix the broken `eslint-config-shakacode` link.
But I was too slow (https://github.com/shakacode/style-guide-javascript/commit/3931352d5f7994f195ce0cb033d6228470e939da) 😄

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/style-guide-javascript/11)

<!-- Reviewable:end -->
